### PR TITLE
Switch backend from TypeScript to Go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+backend/wordgame
+backend/bin/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
 # shaken-and-speared
+
+This repository contains a scaffold for a weekly word game. Each player receives the same set of letters for the week. Players may join a group to compete against one another. The game provides a *word to beat* and each player submits a word built from their remaining letters to score more points than the others.
+
+## Structure
+
+ - `backend/` – Go HTTP server exposing placeholder API endpoints.
+
+## Getting Started
+
+1. Build the server (requires Go):
+
+   ```bash
+   cd backend
+   go build -o wordgame
+   ```
+
+2. Start the server:
+
+   ```bash
+   ./wordgame
+   ```
+
+The server runs on port `3000` by default and exposes the following placeholder endpoints:
+
+- `GET /api/status` – health check.
+- `GET /api/game/week` – retrieve the week's letters.
+- `POST /api/game/word` – submit a word.
+
+These endpoints currently return mock data and should be expanded with real game logic.

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,0 +1,3 @@
+module shaken-and-speared/backend
+
+go 1.20

--- a/backend/main.go
+++ b/backend/main.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+)
+
+type wordRequest struct {
+	Word string `json:"word"`
+}
+
+func statusHandler(w http.ResponseWriter, r *http.Request) {
+	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+}
+
+func weekHandler(w http.ResponseWriter, r *http.Request) {
+	json.NewEncoder(w).Encode(map[string][]string{"letters": []string{"a", "b", "c", "d", "e", "f", "g"}})
+}
+
+func wordHandler(w http.ResponseWriter, r *http.Request) {
+	var req wordRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	json.NewEncoder(w).Encode(map[string]string{"message": "Received word " + req.Word})
+}
+
+func main() {
+	http.HandleFunc("/api/status", statusHandler)
+	http.HandleFunc("/api/game/week", weekHandler)
+	http.HandleFunc("/api/game/word", wordHandler)
+
+	log.Println("Server listening on :3000")
+	log.Fatal(http.ListenAndServe(":3000", nil))
+}


### PR DESCRIPTION
## Summary
- remove old TypeScript backend
- implement a Go HTTP server with placeholder endpoints
- update README instructions for Go
- update `.gitignore` for Go build artifacts

## Testing
- `go build -o wordgame`

------
https://chatgpt.com/codex/tasks/task_e_68489e82426c832cb026c100cc10b8d5